### PR TITLE
Waitlist Tile Update

### DIFF
--- a/components/waitlist/WaitlistCard.jsx
+++ b/components/waitlist/WaitlistCard.jsx
@@ -1,0 +1,92 @@
+/* eslint-disable no-unused-vars */
+// import { makeStyles } from '@material-ui/core/styles';
+// import RemoveWaitlist from './RemoveWaitlist';
+import React from 'react';
+// import { useState } from 'react';
+import { TextField } from '@mui/material';
+import {
+  MdOutlineSettings,
+} from 'react-icons/md';
+import styles from '../../styles/components/WaitlistTileCard.module.css';
+import {
+  H1, H2, H3, B1,
+} from '../ui/typography';
+
+function parseTerms(courseTerms) {
+  return courseTerms.join(', ');
+}
+
+function WaitlistCard(props) {
+  const {
+    color,
+    course,
+  } = props;
+  const terms = parseTerms(course.terms);
+  const courseURL = `/courses/${course.courseDepartment}/${course.courseNum}`;
+  return (
+    <div className={styles.card} style={{ background: color.pastel }}>
+      <div className={styles.edit}>
+        <a
+          href=" "
+        >
+          <MdOutlineSettings className="text-2xl text-black group-hover:text-black" />
+        </a>
+      </div>
+      <div className={styles.waitlistCardsContainer}>
+        <div>
+          <H3>
+            {course.courseDepartment}
+            {' '}
+            {course.courseNum}
+          </H3>
+          <H3 color={color.dark}>
+            {' '}
+            {course.courseName}
+          </H3>
+        </div>
+      </div>
+      <div>
+        <H3 color={color.dark}> position on 23s</H3>
+        <H3>
+          {course.waitlistPos}
+          /
+          {course.waitlistTotal}
+        </H3>
+      </div>
+      <div>
+        <H3 color={color.dark}> terms </H3>
+        {terms}
+      </div>
+      <div>
+        <H3 color={color.dark}> notes </H3>
+        <TextField
+          id="notes"
+          defaultValue="Normal"
+          variant="standard"
+          color="secondary"
+        />
+      </div>
+      <div className={styles.bottomButtons}>
+        <div className={styles.buttonContainer}>
+          <a href={courseURL}>
+            <button className={styles.btn} type="button">
+              Course Info Page
+            </button>
+          </a>
+        </div>
+        <div className={styles.buttonContainer}>
+          <button className={styles.btn} type="button">
+            Remove
+          </button>
+        </div>
+        {/* <div className={styles.buttonContainer}>
+          <div className={styles.button}>
+            <RemoveWaitlist />
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export default WaitlistCard;

--- a/components/waitlist/WaitlistCard.jsx
+++ b/components/waitlist/WaitlistCard.jsx
@@ -25,13 +25,6 @@ function WaitlistCard(props) {
   const courseURL = `/courses/${course.courseDepartment}/${course.courseNum}`;
   return (
     <div className={styles.card} style={{ background: color.pastel }}>
-      <div className={styles.edit}>
-        <a
-          href=" "
-        >
-          <MdOutlineSettings className="text-2xl text-black group-hover:text-black" />
-        </a>
-      </div>
       <div className={styles.waitlistCardsContainer}>
         <div>
           <H3>
@@ -39,14 +32,16 @@ function WaitlistCard(props) {
             {' '}
             {course.courseNum}
           </H3>
-          <H3 color={color.dark}>
-            {' '}
-            {course.courseName}
-          </H3>
+          <a href={courseURL}>
+            <H3 color={color.dark}>
+              {' '}
+              {course.courseName}
+            </H3>
+          </a>
         </div>
       </div>
       <div>
-        <H3 color={color.dark}> position on 23s</H3>
+        <H3 color={color.dark}> position on 23S</H3>
         <H3>
           {course.waitlistPos}
           /
@@ -55,35 +50,14 @@ function WaitlistCard(props) {
       </div>
       <div>
         <H3 color={color.dark}> terms </H3>
-        {terms}
-      </div>
-      <div>
-        <H3 color={color.dark}> notes </H3>
-        <TextField
-          id="notes"
-          defaultValue="Normal"
-          variant="standard"
-          color="secondary"
-        />
+        <H3>{terms}</H3>
       </div>
       <div className={styles.bottomButtons}>
         <div className={styles.buttonContainer}>
-          <a href={courseURL}>
-            <button className={styles.btn} type="button">
-              Course Info Page
-            </button>
-          </a>
-        </div>
-        <div className={styles.buttonContainer}>
           <button className={styles.btn} type="button">
-            Remove
+            Edit
           </button>
         </div>
-        {/* <div className={styles.buttonContainer}>
-          <div className={styles.button}>
-            <RemoveWaitlist />
-          </div>
-        </div> */}
       </div>
     </div>
   );

--- a/pages/waitlist/index.jsx
+++ b/pages/waitlist/index.jsx
@@ -1,59 +1,135 @@
-import React, { useEffect } from 'react';
-import Head from 'next/head';
-import { useDispatch, useSelector } from 'react-redux';
+// import React, { useEffect } from 'react';
+import React from 'react';
+// import Head from 'next/head';
+// import { useDispatch, useSelector } from 'react-redux';
 import styles from '../../styles/WaitlistHome.module.css';
-import SideNavbar from '../../components/SideNavbar';
-import { H2, B1 } from '../../components/ui/typography';
-import WaitlistModal from '../../components/waitlist/WaitlistModal';
-import { fetchWaitlists } from '../../actions';
+// import SideNavbar from '../../components/SideNavbar';
+import { H2 } from '../../components/ui/typography';
+// import WaitlistModal from '../../components/waitlist/WaitlistModal';
+import WaitlistCard from '../../components/waitlist/WaitlistCard';
+// import { fetchWaitlists } from '../../actions';
+
+const cardColors = [
+  { pastel: '#F9F3FC', dark: '#8E5BA8' },
+  { pastel: '#FCF0E3', dark: '#BA7D37' },
+  { pastel: '#EBF9FA', dark: '#5B8A8D' },
+  { pastel: '#EFFAEB', dark: '#75946A' },
+  { pastel: '#EFE7FA', dark: '#7E5DAC' },
+  { pastel: '#FAEBF6', dark: '#AE5E99' },
+  { pastel: '#F9F3FC', dark: '#8E5BA8' },
+  { pastel: '#FCF0E3', dark: '#BA7D37' },
+];
+
+const waitlistMockData = {
+  courses: [
+    {
+      courseDepartment: 'COSC',
+      courseNum: '52',
+      courseName: 'Full-Stack Web Development',
+      waitlistPos: 10,
+      waitlistTotal: 76,
+      terms: ['23S', '24S', '25S'],
+      joined: 'June 21, 2022',
+      comments: '',
+    },
+    {
+      courseDepartment: 'COSC',
+      courseNum: '74',
+      courseName: 'Machine Learning and Statistical Data Analysis',
+      waitlistPos: 2,
+      waitlistTotal: 14,
+      terms: ['23W'],
+      joined: 'April 10, 2022',
+      comments: '',
+    },
+    {
+      courseDepartment: 'MATH',
+      courseNum: '001',
+      courseName: 'Introduction to Calculus',
+      waitlistPos: 5,
+      waitlistTotal: 7,
+      remainingTerms: 1,
+      terms: ['25F'],
+      joined: 'August 14, 2022',
+      comments: '',
+    },
+    {
+      courseDepartment: 'ECON',
+      courseNum: '001',
+      courseName: 'The Price System: Analysis, Problems, and Policies',
+      waitlistPos: 32,
+      waitlistTotal: 35,
+      remainingTerms: 2,
+      terms: ['23X'],
+      joined: 'November 11, 2022',
+      comments: '',
+    },
+  ],
+};
 
 export default function WaitlistHome() {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(fetchWaitlists());
-  }, []);
-  const waitlistContent = useSelector((reduxState) => reduxState.waitlist.current);
   return (
     <div className={styles.container}>
-      <Head>
-        <title>Classy</title>
-        <meta name="description" content="Cool tagline here" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-
-      <SideNavbar />
-
-      <H2 className={styles.title}>
-        My Waitlists
-      </H2>
-
-      <main className={styles.main}>
-        <B1 className="description">
-          Join new waitlists from the course info page.
-        </B1>
-
-        <div className={styles.grid}>
-          {waitlistContent.courses ? waitlistContent.courses.map((course, index) => (
-            <WaitlistModal 
-            course={course}
-            studentId={`ObjectId('${waitlistContent.student._id}')`}
-            onWaitlist={true}
-            index={index}
-            entryPoint={'waitlist'}/>
-          )) : ''}
-        </div>
-      </main>
-
-      <footer className={styles.footer}>
-        <a
-          href="_blank"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-        Classy
-
-        </a>
-      </footer>
+      <H2 color="#14121D">Waitlisted Courses</H2>
+      <p color="#14121D">Join a new waitlist from the course info page.</p>
+      <div className={styles.waitlistCardsContainer}>
+        {waitlistMockData.courses.map((course, i) => (
+          <WaitlistCard course={course} color={cardColors[i % cardColors.length]} />
+        ))}
+      </div>
     </div>
   );
 }
+// export default function WaitlistHome() {
+//   const dispatch = useDispatch();
+//   useEffect(() => {
+//     dispatch(fetchWaitlists());
+//   }, []);
+//   const waitlistContent = useSelector((reduxState) => reduxState.waitlist.current);
+//   return (
+//     <div className={styles.container}>
+//       <Head>
+//         <title>Classy</title>
+//         <meta name="description" content="Cool tagline here" />
+//         <link rel="icon" href="/favicon.ico" />
+//       </Head>
+
+//       <SideNavbar />
+
+//       <H2 className={styles.title}>
+//         My Waitlists
+//       </H2>
+
+//       <main className={styles.main}>
+//         <B1 className="description">
+//           Join new waitlists from the course info page.
+//         </B1>
+
+//         <div className={styles.grid}>
+//           {waitlistContent.courses ? waitlistContent.courses.map((course, index) => (
+//             <WaitlistModal
+//               course={course}
+//               // studentId={`ObjectId('${waitlistContent.student._id}')`}
+//               // eslint-disable-next-line no-underscore-dangle
+//               studentId={`ObjectId('${waitlistContent.student._id}')`}
+//               onWaitlist
+//               index={index}
+//               entryPoint="waitlist"
+//             />
+//           )) : ''}
+//         </div>
+//       </main>
+
+//       <footer className={styles.footer}>
+//         <a
+//           href="_blank"
+//           target="_blank"
+//           rel="noopener noreferrer"
+//         >
+//           Classy
+
+//         </a>
+//       </footer>
+//     </div>
+//   );
+// }

--- a/pages/waitlist/index.jsx
+++ b/pages/waitlist/index.jsx
@@ -1,13 +1,13 @@
-// import React, { useEffect } from 'react';
-import React from 'react';
-// import Head from 'next/head';
-// import { useDispatch, useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+// import React from 'react';
+import Head from 'next/head';
+import { useDispatch, useSelector } from 'react-redux';
 import styles from '../../styles/WaitlistHome.module.css';
-// import SideNavbar from '../../components/SideNavbar';
+import SideNavbar from '../../components/SideNavbar';
 import { H2 } from '../../components/ui/typography';
 // import WaitlistModal from '../../components/waitlist/WaitlistModal';
 import WaitlistCard from '../../components/waitlist/WaitlistCard';
-// import { fetchWaitlists } from '../../actions';
+import { fetchWaitlists } from '../../actions';
 
 const cardColors = [
   { pastel: '#F9F3FC', dark: '#8E5BA8' },
@@ -20,116 +20,81 @@ const cardColors = [
   { pastel: '#FCF0E3', dark: '#BA7D37' },
 ];
 
-const waitlistMockData = {
-  courses: [
-    {
-      courseDepartment: 'COSC',
-      courseNum: '52',
-      courseName: 'Full-Stack Web Development',
-      waitlistPos: 10,
-      waitlistTotal: 76,
-      terms: ['23S', '24S', '25S'],
-      joined: 'June 21, 2022',
-      comments: '',
-    },
-    {
-      courseDepartment: 'COSC',
-      courseNum: '74',
-      courseName: 'Machine Learning and Statistical Data Analysis',
-      waitlistPos: 2,
-      waitlistTotal: 14,
-      terms: ['23W'],
-      joined: 'April 10, 2022',
-      comments: '',
-    },
-    {
-      courseDepartment: 'MATH',
-      courseNum: '001',
-      courseName: 'Introduction to Calculus',
-      waitlistPos: 5,
-      waitlistTotal: 7,
-      remainingTerms: 1,
-      terms: ['25F'],
-      joined: 'August 14, 2022',
-      comments: '',
-    },
-    {
-      courseDepartment: 'ECON',
-      courseNum: '001',
-      courseName: 'The Price System: Analysis, Problems, and Policies',
-      waitlistPos: 32,
-      waitlistTotal: 35,
-      remainingTerms: 2,
-      terms: ['23X'],
-      joined: 'November 11, 2022',
-      comments: '',
-    },
-  ],
-};
+// const waitlistMockData = {
+//   courses: [
+//     {
+//       courseDepartment: 'COSC',
+//       courseNum: '52',
+//       courseName: 'Full-Stack Web Development',
+//       waitlistPos: 10,
+//       waitlistTotal: 76,
+//       terms: ['23S', '24S', '25S'],
+//       joined: 'June 21, 2022',
+//       comments: '',
+//     },
+//     {
+//       courseDepartment: 'COSC',
+//       courseNum: '74',
+//       courseName: 'Machine Learning and Statistical Data Analysis',
+//       waitlistPos: 2,
+//       waitlistTotal: 14,
+//       terms: ['23W'],
+//       joined: 'April 10, 2022',
+//       comments: '',
+//     },
+//     {
+//       courseDepartment: 'MATH',
+//       courseNum: '001',
+//       courseName: 'Introduction to Calculus',
+//       waitlistPos: 5,
+//       waitlistTotal: 7,
+//       remainingTerms: 1,
+//       terms: ['25F'],
+//       joined: 'August 14, 2022',
+//       comments: '',
+//     },
+//     {
+//       courseDepartment: 'ECON',
+//       courseNum: '001',
+//       courseName: 'The Price System: Analysis, Problems, and Policies',
+//       waitlistPos: 32,
+//       waitlistTotal: 35,
+//       remainingTerms: 2,
+//       terms: ['23X'],
+//       joined: 'November 11, 2022',
+//       comments: '',
+//     },
+//   ],
+// };
 
 export default function WaitlistHome() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchWaitlists());
+  }, []);
+  const waitlistContent = useSelector((reduxState) => reduxState.waitlist.current);
   return (
     <div className={styles.container}>
-      <H2 color="#14121D">Waitlisted Courses</H2>
+      <Head>
+        <title>Classy</title>
+        <meta name="description" content="Cool tagline here" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      <SideNavbar />
+
+      <H2 className={styles.title}>
+        My Waitlists
+      </H2>
       <p color="#14121D">Join a new waitlist from the course info page.</p>
       <div className={styles.waitlistCardsContainer}>
-        {waitlistMockData.courses.map((course, i) => (
-          <WaitlistCard course={course} color={cardColors[i % cardColors.length]} />
-        ))}
+        {waitlistContent.courses ? waitlistContent.courses.map((course, i) => (
+          <WaitlistCard
+            course={course}
+            color={cardColors[i % cardColors.length]}
+          />
+        )) : ''}
       </div>
     </div>
   );
 }
-// export default function WaitlistHome() {
-//   const dispatch = useDispatch();
-//   useEffect(() => {
-//     dispatch(fetchWaitlists());
-//   }, []);
-//   const waitlistContent = useSelector((reduxState) => reduxState.waitlist.current);
-//   return (
-//     <div className={styles.container}>
-//       <Head>
-//         <title>Classy</title>
-//         <meta name="description" content="Cool tagline here" />
-//         <link rel="icon" href="/favicon.ico" />
-//       </Head>
-
-//       <SideNavbar />
-
-//       <H2 className={styles.title}>
-//         My Waitlists
-//       </H2>
-
-//       <main className={styles.main}>
-//         <B1 className="description">
-//           Join new waitlists from the course info page.
-//         </B1>
-
-//         <div className={styles.grid}>
-//           {waitlistContent.courses ? waitlistContent.courses.map((course, index) => (
-//             <WaitlistModal
-//               course={course}
-//               // studentId={`ObjectId('${waitlistContent.student._id}')`}
-//               // eslint-disable-next-line no-underscore-dangle
-//               studentId={`ObjectId('${waitlistContent.student._id}')`}
-//               onWaitlist
-//               index={index}
-//               entryPoint="waitlist"
-//             />
-//           )) : ''}
-//         </div>
-//       </main>
-
-//       <footer className={styles.footer}>
-//         <a
-//           href="_blank"
-//           target="_blank"
-//           rel="noopener noreferrer"
-//         >
-//           Classy
-
-//         </a>
-//       </footer>
-//     </div>
-//   );
-// }

--- a/styles/WaitlistHome.module.css
+++ b/styles/WaitlistHome.module.css
@@ -3,7 +3,7 @@
     margin-left: 300px;
 }
 
-.main {
+/* .main {
   min-height: 100vh;
   padding: 2rem 0;
   flex: 1;
@@ -11,7 +11,7 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
-}
+} */
 
 .footer {
   display: flex;

--- a/styles/WaitlistHome.module.css
+++ b/styles/WaitlistHome.module.css
@@ -16,7 +16,7 @@
   padding-top: 2%;
   display: flex;
   flex-wrap: wrap;
-  gap: 60px;
+  gap: 20px;
   margin: 20px;
   text-decoration: none;
 }

--- a/styles/WaitlistHome.module.css
+++ b/styles/WaitlistHome.module.css
@@ -1,137 +1,22 @@
 .container {
-    padding: 0 2rem;
-    margin-left: 300px;
+  padding: 0 2rem;
+  margin-top: 50px;
+  margin-left: 250px;
 }
 
-/* .main {
-  min-height: 100vh;
-  padding: 2rem 0;
+.main {
   flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
-} */
-
-.footer {
-  display: flex;
-  flex: 1;
-  padding: 2rem 0;
-  border-top: 1px solid #eaeaea;
-  justify-content: center;
-  align-items: center;
 }
 
-.footer a {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-grow: 1;
-}  
-
-.title a {
-  color: #0070f3;
-  text-decoration: none;
-}
-
-/* .title a:hover,
-.title a:focus,
-.title a:active {
-  text-decoration: underline;
-} */
-
-.title {
-  padding-top: 2%;
-  margin-bottom: 0px;
-  font-size: 2.3rem;
-  display: flex;
-  align-items: flex-start;
-}
-
-.title,
-.description {
-  text-align: left;
-}
-
-.description {
-  margin: 2rem 2rem;
-  padding-bottom: 2%;
-  line-height: 1.5;
-  font-size: 1.5rem;
-}
-
-.code {
-  background: #fafafa;
-  border-radius: 5px;
-  padding: 0.75rem;
-  font-size: 1.1rem;
-  font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
-    Bitstream Vera Sans Mono, Courier New, monospace;
-}
-
-.grid {
-  padding-left: 4%;
+.waitlistCardsContainer {
   padding-top: 2%;
   display: flex;
-  align-items: flex-start;
-  justify-content: left;
   flex-wrap: wrap;
-  /* max-width: 80%; */
-}
-
-.card {
-  width: 375px;
-  height: 200px;
-  margin: 1rem;
-  padding: 1.5rem;
-  text-align: left;
-  background-color: #EBF9FA;
-  color: #5B8A8D;
+  gap: 60px;
+  margin: 20px;
   text-decoration: none;
-  /* border: 2px solid #EBF9FA; */
-  border-radius: 10px;
-  transition: color 0.15s ease, border-color 0.15s ease;
-  max-width: 300px;
 }
-
-.card:hover,
-.card:focus,
-.card:active {
-  opacity: 0.5;
-}
-
-.card h2 {
-  margin: 0 0 1rem 0;
-  font-size: 1.5rem;
-}
-
-.card p {
-  margin: 0;
-  font-size: 1.25rem;
-  line-height: 1.5;
-}
-
-.logo {
-  height: 1em;
-  margin-left: 0.5rem;
-}
-
-@media (max-width: 600px) {
-  .grid {
-    width: 100%;
-    flex-direction: column;
-  }
-}
-
-@media (prefers-color-scheme: light) {
-  .card,
-  .footer {
-    border-color: #222;
-  }
-  .code {
-    background: #111;
-  }
-  .logo img {
-    filter: invert(1);
-  }
-}  

--- a/styles/components/WaitlistTileCard.module.css
+++ b/styles/components/WaitlistTileCard.module.css
@@ -1,0 +1,64 @@
+.card {
+  width: 400px;
+  min-width: 300px;
+  height: 550px;
+  margin: 1rem;
+  padding: 1.5rem;
+  text-align: left;
+  text-decoration: none;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.courseTitle {
+  font-family: 'Asap';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 42px;
+  line-height: 48px;
+}
+
+.bottomButtons {
+  padding-top: 30px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+}
+
+.buttonContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.edit {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  background-color: #14121D;
+  border-color: transparent;
+  border-radius: 10px;
+  color: white;
+  height: 50px;
+  width: 150px;
+  text-align: center;
+  justify-content: center;
+  text-decoration: none;
+  font-size: 16px;
+}
+
+.btn:hover,
+.btn:visited,
+.btn:focus,
+.btn:active {
+  color: #14121D;
+  background-color: #fafafa;
+  border-color: transparent;
+}

--- a/styles/components/WaitlistTileCard.module.css
+++ b/styles/components/WaitlistTileCard.module.css
@@ -1,7 +1,7 @@
 .card {
-  width: 400px;
+  width: 350px;
   min-width: 300px;
-  height: 550px;
+  height: 400px;
   margin: 1rem;
   padding: 1.5rem;
   text-align: left;


### PR DESCRIPTION
restored waitlist tile formatting from pr 487e478. Single waitlist dashboard with relevant waitlist/course information displayed in tiles. Lists current terms on the waitlist as well as the current position for the upcoming term. Fixed CSS bug, tile scale issue, data, and updated the tile to show the correct information. Not connected to backend, instead getting mock waitlist data passed in from waitlist>index.js.
Known bug: tiles not displaying in grid, but instead as a single column
<img width="1128" alt="waitlistProgress1" src="https://user-images.githubusercontent.com/77239320/218547187-bb815d75-c3e7-4378-b4b7-18429669be7e.png">
