### PR TITLE
Gyuri/side nav bar changes on students side

### DIFF
--- a/components/SideNav.jsx
+++ b/components/SideNav.jsx
@@ -9,7 +9,6 @@ function SideNav() {
       <Link href="/search">Search</Link>
       <Link href="/social">Social</Link>
       <Link href="/waitlist">Waitlists</Link>
-      <Link href="/settings">Settings</Link>
     </nav>
   );
 }

--- a/components/SideNavbar.js
+++ b/components/SideNavbar.js
@@ -8,7 +8,6 @@ import {
   MdOutlineSearch,
   MdPeopleOutline,
   MdOutlineFormatListBulleted,
-  MdOutlineSettings,
   MdOutlineLogout,
 } from 'react-icons/md';
 import { H4 } from './ui/typography';
@@ -29,13 +28,13 @@ function SideNavbar() {
           />
         </Disclosure.Button>
         <div className="p-6 w-1/2 h-screen bg-black z-20 fixed top-0 -left-96 lg:w-60 lg:left-0 peer-focus:left-0 peer:transition ease-out delay-150 duration-200">
-          <div className="flex flex-col justify-start items-center">
+          <div className="flex flex-col justify-start items-center my-6">
             <Image src={logo} width={60} height={60} alt="classy logo" />
             <H4
               color="white"
               className="text-base text-center cursor-pointer font-bold pb-4 w-full mt-3.5"
             >
-              Hi, Tim!
+              Classy
             </H4>
 
             {/* main tabs */}
@@ -64,11 +63,6 @@ function SideNavbar() {
                 icon={<MdOutlineFormatListBulleted className={sidenavLinkStyles} />}
               />
 
-              <NavbarLink
-                link="settings"
-                title="Settings"
-                icon={<MdOutlineSettings className={sidenavLinkStyles} />}
-              />
             </div>
 
             {/* logout */}


### PR DESCRIPTION
- changed Hi, Tim to Classy
- removed settings
- added margin at top
<img width="1512" alt="Screen Shot 2023-02-25 at 4 25 52 PM" src="https://user-images.githubusercontent.com/61445037/221380308-0e3669e6-fbc7-46c5-bb33-df70da429df0.png">
