### PR TITLE
Alyssa/login reg fix

### DIFF
--- a/components/register/Register.jsx
+++ b/components/register/Register.jsx
@@ -70,11 +70,7 @@ function Register() {
     dispatch(loadRegister());
   }, []);
   const depts = useSelector(
-<<<<<<< HEAD
     (reduxState) => reduxState?.auth?.current?.response?.depts,
-=======
-    (reduxState) => reduxState.auth?.current?.response?.depts,
->>>>>>> d48c2b2f354bbe60d9599e67eda6403f4b3df7d3
   );
   const errors = useSelector(
     (reduxState) => {
@@ -104,13 +100,6 @@ function Register() {
     }
     if (!validMatch) list.push('Please enter matching passwords');
 
-<<<<<<< HEAD
-=======
-    // if (errors) {
-    //   list.push(...errors);
-    // }
-
->>>>>>> d48c2b2f354bbe60d9599e67eda6403f4b3df7d3
     if (list.length) {
       return (
         <Alert severity="error" style={{ width: '100%' }}>

--- a/pages/Login/index.jsx
+++ b/pages/Login/index.jsx
@@ -7,7 +7,7 @@ import styles from '../../styles/Login.module.css';
 
 export default function LoginHome() {
   return (
-    <div className={styles.container}>
+    <div className={styles.loginContainer}>
       <main className="LoginHome">
         <Login />
       </main>

--- a/pages/Register/index.jsx
+++ b/pages/Register/index.jsx
@@ -7,7 +7,7 @@ import styles from '../../styles/Login.module.css';
 
 export default function RegisterHome() {
   return (
-    <div className={styles.container}>
+    <div className={styles.registerContainer}>
       <main className="RegisterHome">
         <Register />
       </main>

--- a/styles/Login.module.css
+++ b/styles/Login.module.css
@@ -1,7 +1,13 @@
-.container {
-  /* padding: 0 2rem; */
+.registerContainer {
+  padding-top: 3%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  /* background: #14121D; */
+}
+
+.loginContainer {
   padding-top: 8%;
-  height: 700px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -27,7 +33,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  padding: 10%;
+  padding: 8%;
   padding-left: 12%;
 }
 

--- a/styles/Login.module.css
+++ b/styles/Login.module.css
@@ -1,6 +1,6 @@
 .container {
-  padding: 0 2rem;
-  margin-left: 200px;
+  /* padding: 0 2rem; */
+  padding-top: 8%;
   height: 700px;
   display: flex;
   justify-content: center;

--- a/styles/Register.module.css
+++ b/styles/Register.module.css
@@ -2,8 +2,8 @@
   color: #14121D ;
   display: flex;
   justify-content: center;
-  padding-top: 2%;
-  padding-bottom: 8%;
+  padding-top: 5%;
+  padding-bottom: 2%;
 }
 
 .rowcontainer {

--- a/styles/Register.module.css
+++ b/styles/Register.module.css
@@ -2,7 +2,7 @@
   color: #14121D ;
   display: flex;
   justify-content: center;
-  padding-top: 5%;
+  padding-top: 2%;
   padding-bottom: 2%;
 }
 


### PR DESCRIPTION
updated login and register pages. links now go to /register and /login. centered login and ensured title is visible
<img width="1552" alt="Screenshot 2023-03-04 at 4 43 18 PM" src="https://user-images.githubusercontent.com/77239320/222929922-c363060f-cd64-42d7-bc4a-9bf9dc349efa.png">
<img width="1552" alt="Screenshot 2023-03-04 at 4 43 06 PM" src="https://user-images.githubusercontent.com/77239320/222929924-8f6d92cc-38b2-4f49-94f3-a6f2c78f2cbe.png">
