### PR TITLE
waitlist tile color and waitlist box link on homepage

### DIFF
--- a/components/waitlist/WaitlistModal.jsx
+++ b/components/waitlist/WaitlistModal.jsx
@@ -168,23 +168,23 @@ function WaitlistModal(props) {
       return (
         <div
           className={styleswt.card}
-          style={{ background: cardColor[index] }}
+          style={{ background: cardColor[index % 6] }}
         >
           <div className={styleswt.waitlistCardsContainer}>
             <H3>
               {` ${course.courseDept} ${course.courseNum}`}
             </H3>
             <Link href={`/courses/${course.courseDept}/${course.courseNum}`}>
-              <H3 color={textColor[index]}>{course.courseTitle}</H3>
+              <H3 color={textColor[index % 6]}>{course.courseTitle}</H3>
             </Link>
           </div>
           <div className={styleswt.waitlistCardsContainer}>
             <div>
-              <H3 color={textColor[index]}>terms enrolled</H3>
+              <H3 color={textColor[index % 6]}>terms enrolled</H3>
               <H3>{waitlistTerms}</H3>
             </div>
             <div>
-              <H3 color={textColor[index]}>
+              <H3 color={textColor[index % 6]}>
                 status for
                 {' '}
                 {nextTerm}

--- a/pages/home/index.jsx
+++ b/pages/home/index.jsx
@@ -5,6 +5,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-unused-vars */
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useSelector, useDispatch } from 'react-redux';
 
 import {
@@ -280,14 +281,16 @@ function HomePage() {
                   pastelColor="var(--pastel-pink)"
                   darkColor="var(--dark-pink) "
                 />
-                <DataBox
-                  height="180px"
-                  width="175px"
-                  text="Waitlists Joined"
-                  data={waitlists?.courses?.length || 0}
-                  pastelColor="var(--pastel-violet)"
-                  darkColor="var(--dark-violet) "
-                />
+                <Link href="/waitlist">
+                  <DataBox
+                    height="180px"
+                    width="175px"
+                    text="Waitlists Joined"
+                    data={waitlists?.courses?.length || 0}
+                    pastelColor="var(--pastel-violet)"
+                    darkColor="var(--dark-violet) "
+                  />
+                </Link>
               </div>
             </div>
           </div>

--- a/pages/waitlist/index.jsx
+++ b/pages/waitlist/index.jsx
@@ -49,7 +49,6 @@ export default function WaitlistHome() {
               course={course}
               studentId={student._id}
               onWaitlist
-              // offering={course.offering}
               index={index}
               entryPoint="waitlist"
             />


### PR DESCRIPTION
Waitlist box on homepage now links to waitlist dashboard
![Uploading Screenshot 2023-03-11 at 3.16.17 PM.png…]()

Waitlist tiles are no longer white for more than 6 active waitlists
![Uploading Screenshot 2023-03-11 at 3.16.01 PM.png…]()
